### PR TITLE
compass: add netty-tcnative-boringssl-static to runtime dependencies for TLS

### DIFF
--- a/compass/BUILD
+++ b/compass/BUILD
@@ -4,6 +4,7 @@ COORDINATOR_RUNTIME_DEPS = [
     "@com_squareup_retrofit2_converter_gson//jar",
     "@com_squareup_retrofit2_retrofit//jar",
     "@com_squareup_okio_okio//jar",
+    "@io_netty_netty_tcnative_boringssl_static//jar",
 ]
 
 java_binary(


### PR DESCRIPTION
The binaries need to be available as runtime dependency so that gRPC can use TLS.