### PR TITLE
Make Compass stateful

### DIFF
--- a/compass/Coordinator.java
+++ b/compass/Coordinator.java
@@ -93,15 +93,21 @@ public class Coordinator {
     oos.close();
   }
 
-
   public static void main(String[] args) throws Exception {
     CoordinatorConfiguration config = new CoordinatorConfiguration();
     CoordinatorState state;
-    try {
-      state = loadState();
-    } catch (FileNotFoundException e) {
-      log.warn("No Compass state file found! Starting with an empty state.");
+    // We want an empty state if bootstrapping
+    if (config.bootstrap) {
       state = new CoordinatorState();
+    } else {
+      try {
+        state = loadState();
+      } catch (Exception e) {
+        String msg = "Error loading Compass state file! This should not happen unless when bootstrapping.";
+
+        log.error(msg);
+        throw new RuntimeException(msg);
+      }
     }
 
     JCommander.newBuilder()

--- a/compass/Coordinator.java
+++ b/compass/Coordinator.java
@@ -116,7 +116,7 @@ public class Coordinator {
       } catch (Exception e) {
         String msg = "Error loading Compass state file '" + statePath + "'! State file required if not bootstrapping.";
 
-        log.error(msg, e.getMessage());
+        log.error(msg, e);
         throw new RuntimeException(e);
       }
     }
@@ -336,7 +336,7 @@ public class Coordinator {
       } catch (Exception e) {
         String msg = "Error saving Compass state to file '" + statePath + "'!";
 
-        log.error(msg, e.getMessage());
+        log.error(msg, e);
         throw new RuntimeException(e);
       }
 

--- a/compass/Coordinator.java
+++ b/compass/Coordinator.java
@@ -50,7 +50,7 @@ public class Coordinator {
   private final MilestoneSource db;
   private final IotaAPI api;
   private final CoordinatorConfiguration config;
-  private final CoordinatorState state;
+  private CoordinatorState state;
   private List<IotaAPI> validatorAPIs;
 
   private long milestoneTick;
@@ -194,6 +194,7 @@ public class Coordinator {
     }
 
     if (config.index != null) {
+      state = new CoordinatorState();
       state.latestMilestoneIndex = config.index;
     }
 

--- a/compass/Coordinator.java
+++ b/compass/Coordinator.java
@@ -80,16 +80,28 @@ public class Coordinator {
 
   private static CoordinatorState loadState() throws IOException, ClassNotFoundException {
     CoordinatorState state;
-    ObjectInputStream ois = new ObjectInputStream(new FileInputStream(CoordinatorState.COORDINATOR_STATE_PATH));
-    state = (CoordinatorState) ois.readObject();
-    ois.close();
+    ObjectInputStream ois = null;
+    try {
+      ois = new ObjectInputStream(new FileInputStream(CoordinatorState.COORDINATOR_STATE_PATH));
+      state = (CoordinatorState) ois.readObject();
+    } finally {
+      if (ois != null) {
+        ois.close();
+      }
+    }
     return state;
   }
 
   private void storeState(CoordinatorState state) throws IOException {
-    ObjectOutputStream oos = new ObjectOutputStream(new FileOutputStream(CoordinatorState.COORDINATOR_STATE_PATH));
-    oos.writeObject(state);
-    oos.close();
+    ObjectOutputStream oos = null;
+    try {
+      oos = new ObjectOutputStream(new FileOutputStream(CoordinatorState.COORDINATOR_STATE_PATH));
+      oos.writeObject(state);
+    } finally {
+      if (oos != null) {
+        oos.close();
+      }
+    }
   }
 
   public static void main(String[] args) throws Exception {

--- a/compass/Coordinator.java
+++ b/compass/Coordinator.java
@@ -116,7 +116,7 @@ public class Coordinator {
       } catch (Exception e) {
         String msg = "Error loading Compass state file '" + statePath + "'! State file required if not bootstrapping.";
 
-        log.error(msg);
+        log.error(msg, e.getMessage());
         throw new RuntimeException(e);
       }
     }
@@ -336,7 +336,7 @@ public class Coordinator {
       } catch (Exception e) {
         String msg = "Error saving Compass state to file '" + statePath + "'!";
 
-        log.error(msg);
+        log.error(msg, e.getMessage());
         throw new RuntimeException(e);
       }
 

--- a/compass/Coordinator.java
+++ b/compass/Coordinator.java
@@ -37,11 +37,7 @@ import org.iota.compass.conf.CoordinatorState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.FileOutputStream;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
+import java.io.*;
 import java.net.URI;
 import java.net.URL;
 import java.util.List;
@@ -100,7 +96,13 @@ public class Coordinator {
 
   public static void main(String[] args) throws Exception {
     CoordinatorConfiguration config = new CoordinatorConfiguration();
-    CoordinatorState state = loadState();
+    CoordinatorState state;
+    try {
+      state = loadState();
+    } catch (FileNotFoundException e) {
+      log.warn("No Compass state file found! Starting with an empty state.");
+      state = new CoordinatorState();
+    }
 
     JCommander.newBuilder()
         .addObject(config)

--- a/compass/conf/CoordinatorConfiguration.java
+++ b/compass/conf/CoordinatorConfiguration.java
@@ -55,4 +55,7 @@ public class CoordinatorConfiguration extends BaseConfiguration {
   @Parameter(names = "-validator", description = "Validator nodes to use")
   public List<String> validators = new ArrayList<>();
 
+  @Parameter(names = "-propagationRetriesThreshold", description = "Number of milestone propagation retries we attempt before failing.")
+  public int propagationRetriesThreshold = 5;
+
 }

--- a/compass/conf/CoordinatorState.java
+++ b/compass/conf/CoordinatorState.java
@@ -34,7 +34,7 @@ public class CoordinatorState implements Serializable {
 
   public static final String COORDINATOR_STATE_PATH = "compass.state";
 
-  public Integer latestMilestoneIndex;
+  public int latestMilestoneIndex;
   public String latestMilestoneHash;
   public long latestMilestoneTime;
   public List<Transaction> latestMilestoneTransactions;

--- a/compass/conf/CoordinatorState.java
+++ b/compass/conf/CoordinatorState.java
@@ -1,0 +1,42 @@
+/*
+ * This file is part of TestnetCOO.
+ *
+ * Copyright (C) 2018 IOTA Stiftung
+ * TestnetCOO is Copyright (C) 2017-2018 IOTA Stiftung
+ *
+ * TestnetCOO is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * TestnetCOO is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with TestnetCOO.  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     IOTA Stiftung <contact@iota.org>
+ *     https://www.iota.org/
+ */
+
+package org.iota.compass.conf;
+
+import jota.model.Transaction;
+
+import java.io.Serializable;
+import java.util.List;
+
+public class CoordinatorState implements Serializable {
+
+  public static final String COORDINATOR_STATE_PATH = "compass.state";
+
+  public Integer latestMilestoneIndex;
+  public String latestMilestoneHash;
+  public long latestMilestoneTime;
+  public List<Transaction> latestMilestoneTransactions;
+
+}


### PR DESCRIPTION
Compass now saves and restores information about latest Milestone instead of relying on `getNodeInfo`.
This will ensure we always use the latest issued milestone as starting point for gTTA.

* If the latest milestone returned by `getNodeInfo` has not the same index as the one stored in the state, Compass will:
  * Re-broadcast the previous milestone.
  * Wait a third of milestoneTick before checking again. 
  * Please note that the index is checked for equality `==`: we want to make sure node and Compass *are on the same page*.
  * If the above happens more than `MILESTONE_PROPAGATION_FAILS_THRESHOLD` (currently 5) Compass bails with an unrecoverable error. If things turn south this way we should not try to handle it in code.
* Compass always needs a state file to start from, unless in `-bootstrap` mode, in which case the initialized state is empty.

Fixes #2 