### PR TITLE
delete set unprivileged users parameters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ before_install:
     if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
       OS=darwin
     else
-      sysctl kernel.unprivileged_userns_clone=1
       OS=linux
     fi
     URL="https://github.com/bazelbuild/bazel/releases/download/${V}/bazel-${V}-installer-${OS}-x86_64.sh"


### PR DESCRIPTION
The Travis log prints:
``sysctl: permission denied on key 'kernel.unprivileged_userns_clone'`

Since the tests seem to pass I conclude that setting this parameter is useless and it just prints confusing messages.