### PR TITLE
Feature: automatically reference last milestone

### DIFF
--- a/compass/BUILD
+++ b/compass/BUILD
@@ -55,6 +55,7 @@ java_binary(
     runtime_deps = COORDINATOR_RUNTIME_DEPS,
     deps = [
         "//compass/conf",
+        "//compass/exceptions",
         "//compass/milestone",
         "//compass/sign:common",
         "//compass/sign:helper",

--- a/compass/exceptions/BUILD
+++ b/compass/exceptions/BUILD
@@ -1,0 +1,9 @@
+MAIN_BASE_PATH = "src/main/java/org/iota/compass/%s"
+
+java_library(
+    name = "exceptions",
+    srcs = glob([
+        "*.java",
+    ]),
+    visibility = ["//visibility:public"],
+)

--- a/compass/exceptions/TimeoutException.java
+++ b/compass/exceptions/TimeoutException.java
@@ -1,0 +1,26 @@
+package org.iota.compass.exceptions;
+
+/**
+ * Thrown if an API call to IRI is timed out
+ */
+public class TimeoutException extends Exception {
+
+    public TimeoutException() {
+    }
+
+    public TimeoutException(String message) {
+        super(message);
+    }
+
+    public TimeoutException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public TimeoutException(Throwable cause) {
+        super(cause);
+    }
+
+    public TimeoutException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}


### PR DESCRIPTION
# Description
If we get an error from GTTA that includes the phrase "exceeded timeout" we shall automatically reference the last milestone.

fixes #104 

# How was this tested
Compass was ran locally against an IRI node and results were verified with a tangle explorer