### PR TITLE
fix regression in "bootstrap" refactoring

### DIFF
--- a/compass/conf/CoordinatorConfiguration.java
+++ b/compass/conf/CoordinatorConfiguration.java
@@ -47,7 +47,7 @@ public class CoordinatorConfiguration extends BaseConfiguration {
   public int maxDepth = 1000;
 
   @Parameter(names = "-depthScale", description = "Time scale factor for depth decrease")
-  public float depthScale = 1.01f;
+  public float depthScale = 1.05f;
 
   @Parameter(names = "-unsolidDelay", description = "Delay if node is not solid in milliseconds")
   public int unsolidDelay = 5000;


### PR DESCRIPTION
fixes #103 
1. makes sure depth is updated when the bootstrap stage is over
1. makes sure depth is updated when bootstrap is not enabled
1. set a more achievable `depthScale` - 5%, this means that if generating the milestone took less than 5% of the `tick` time the depth will rise. so for 60sec ticks 3sec generation.