### PR TITLE
DNS caching fix

### DIFF
--- a/Security.MD
+++ b/Security.MD
@@ -1,0 +1,23 @@
+<h2>Responsible disclosure policy</h2>
+
+At the IOTA Foundation, we consider the security of our systems a top priority. But no matter how much effort we put into system security, there can still be vulnerabilities present. If you've discovered a vulnerability, please follow the guidelines below to report it to our security team:
+<ul>
+	<li>E-mail your findings to secops@iota.org. If the report contains highly sensitive information, please consider encrypting your findings using our contact@iota.org (466385BD0B40D9550F93C04746A440CCE5664A64) PGP key.</li>
+</ul>
+Please follow these rules when testing/reporting vulnerabilities:
+<ul>
+	<li>Do not take advantage of the vulnerability you have discovered, for example by downloading more data than is necessary to demonstrate the vulnerability.</li>
+	<li>Do not read, modify or delete data that isn't you own.</li>
+	<li>We ask that you do not to disclosure the problem to third parties until it has been resolved.</li>
+	<li>The scope of the program is limited to technical vulnerabilities in IOTA Foundations's web applications and open source software packages distributed through GitHub, please do not try to test physical security or attempt phishing attacks against our employees, and so on.</li>
+	<li>Out of concern for the availability of our services to all users, please do not attempt to carry out DoS attacks, leverage black hat SEO techniques, spam people, and do other similarly questionable things. We also discourage the use of any vulnerability testing tools that automatically generate significant volumes of traffic.</li>
+</ul>
+What we promise:
+<ul>
+	<li>We will respond to your report within 3 business days with our evaluation of the report and an expected resolution date.</li>
+	<li>If you have followed the instructions above, we will not take any legal action against you in regard to the report.</li>
+	<li>We will keep you informed during all stages of resolving the problem.</li>
+	<li>To show our appreciation for your effort and cooperation during the report, we will list your name and a link to a personal website/social network profile on the page below so that the public can know you've helped keep the IOTA Foundation secure.</li>
+</ul>
+We sincerely appreciate the efforts of security researchers in keeping our community safe.
+

--- a/compass/BUILD
+++ b/compass/BUILD
@@ -59,6 +59,7 @@ java_binary(
         "//compass/milestone",
         "//compass/sign:common",
         "//compass/sign:helper",
+        "//compass/sign:remote",
         "@com_beust_jcommander//jar",
         "@org_iota_jota//jar",
         "@org_slf4j_slf4j_api//jar",

--- a/compass/Coordinator.java
+++ b/compass/Coordinator.java
@@ -38,6 +38,7 @@ import org.slf4j.LoggerFactory;
 import java.io.*;
 import java.net.URI;
 import java.net.URL;
+import java.rmi.Remote;
 import java.security.Security;
 import java.util.List;
 import java.util.Objects;
@@ -120,8 +121,8 @@ public class Coordinator {
   public static void main(String[] args) throws Exception {
 
     // Limit DNS caching for resolved and failed records to 5 seconds
-    Security.setProperty("networkaddress.cache.ttl" , "5");
-    Security.setProperty("networkaddress.cache.negative.ttl" , "5");
+    Security.setProperty("networkaddress.cache.ttl" , RemoteSignatureSource.DEFAULT_CACHE_TTL);
+    Security.setProperty("networkaddress.cache.negative.ttl" , RemoteSignatureSource.DEFAULT_CACHE_TTL);
 
     CoordinatorConfiguration config = new CoordinatorConfiguration();
     CoordinatorState state;

--- a/compass/Coordinator.java
+++ b/compass/Coordinator.java
@@ -36,6 +36,7 @@ import org.slf4j.LoggerFactory;
 import java.io.*;
 import java.net.URI;
 import java.net.URL;
+import java.security.Security;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -113,6 +114,11 @@ public class Coordinator {
   }
 
   public static void main(String[] args) throws Exception {
+
+    // Limit DNS caching for resolved and failed records to 5 seconds
+    Security.setProperty("networkaddress.cache.ttl" , "5");
+    Security.setProperty("networkaddress.cache.negative.ttl" , "5");
+
     CoordinatorConfiguration config = new CoordinatorConfiguration();
     CoordinatorState state;
 

--- a/compass/sign/RemoteSignatureSource.java
+++ b/compass/sign/RemoteSignatureSource.java
@@ -65,9 +65,13 @@ public class RemoteSignatureSource extends SignatureSource {
                                                                   String trustCertCollectionFilePath,
                                                                   String clientCertChainFilePath,
                                                                   String clientPrivateKeyFilePath) throws SSLException {
+    String cacheTtl = Security.getProperty("networkaddress.cache.ttl");
+    if (cacheTtl == null) {
+      cacheTtl = "5";
+    }
     return NettyChannelBuilder
       .forTarget(uri)
-      .idleTimeout(Integer.valueOf(Security.getProperty("networkaddress.cache.ttl")) * 2, TimeUnit.SECONDS)
+      .idleTimeout(Integer.valueOf(cacheTtl) * 2, TimeUnit.SECONDS)
       .useTransportSecurity()
       .sslContext(
         buildSslContext(trustCertCollectionFilePath, clientCertChainFilePath, clientPrivateKeyFilePath)
@@ -75,9 +79,13 @@ public class RemoteSignatureSource extends SignatureSource {
   }
 
   private ManagedChannelBuilder createPlaintextManagedChannelBuilder(String uri) {
+    String cacheTtl = Security.getProperty("networkaddress.cache.ttl");
+    if (cacheTtl == null) {
+      cacheTtl = "5";
+    }
     return ManagedChannelBuilder
       .forTarget(uri)
-      .idleTimeout(Integer.valueOf(Security.getProperty("networkaddress.cache.ttl")) * 2, TimeUnit.SECONDS)
+      .idleTimeout(Integer.valueOf(cacheTtl) * 2, TimeUnit.SECONDS)
       .usePlaintext();
   }
 

--- a/compass/sign/RemoteSignatureSource.java
+++ b/compass/sign/RemoteSignatureSource.java
@@ -22,6 +22,7 @@ import java.util.concurrent.TimeUnit;
  */
 public class RemoteSignatureSource extends SignatureSource {
   private static final Logger log = LoggerFactory.getLogger(RemoteSignatureSource.class);
+  private static final String defaultCacheTtl = "5";
 
   private SignatureSourceGrpc.SignatureSourceBlockingStub serviceStub;
   private final ManagedChannelBuilder channelBuilder;
@@ -67,7 +68,7 @@ public class RemoteSignatureSource extends SignatureSource {
                                                                   String clientPrivateKeyFilePath) throws SSLException {
     String cacheTtl = Security.getProperty("networkaddress.cache.ttl");
     if (cacheTtl == null) {
-      cacheTtl = "5";
+      cacheTtl = defaultCacheTtl;
     }
     return NettyChannelBuilder
       .forTarget(uri)
@@ -81,7 +82,7 @@ public class RemoteSignatureSource extends SignatureSource {
   private ManagedChannelBuilder createPlaintextManagedChannelBuilder(String uri) {
     String cacheTtl = Security.getProperty("networkaddress.cache.ttl");
     if (cacheTtl == null) {
-      cacheTtl = "5";
+      cacheTtl = defaultCacheTtl;
     }
     return ManagedChannelBuilder
       .forTarget(uri)

--- a/compass/sign/RemoteSignatureSource.java
+++ b/compass/sign/RemoteSignatureSource.java
@@ -22,7 +22,7 @@ import java.util.concurrent.TimeUnit;
  */
 public class RemoteSignatureSource extends SignatureSource {
   private static final Logger log = LoggerFactory.getLogger(RemoteSignatureSource.class);
-  private static final String defaultCacheTtl = "5";
+  public static final String DEFAULT_CACHE_TTL = "5";
 
   private SignatureSourceGrpc.SignatureSourceBlockingStub serviceStub;
   private final ManagedChannelBuilder channelBuilder;
@@ -68,7 +68,7 @@ public class RemoteSignatureSource extends SignatureSource {
                                                                   String clientPrivateKeyFilePath) throws SSLException {
     String cacheTtl = Security.getProperty("networkaddress.cache.ttl");
     if (cacheTtl == null) {
-      cacheTtl = defaultCacheTtl;
+      cacheTtl = DEFAULT_CACHE_TTL;
     }
     return NettyChannelBuilder
       .forTarget(uri)
@@ -82,7 +82,7 @@ public class RemoteSignatureSource extends SignatureSource {
   private ManagedChannelBuilder createPlaintextManagedChannelBuilder(String uri) {
     String cacheTtl = Security.getProperty("networkaddress.cache.ttl");
     if (cacheTtl == null) {
-      cacheTtl = defaultCacheTtl;
+      cacheTtl = DEFAULT_CACHE_TTL;
     }
     return ManagedChannelBuilder
       .forTarget(uri)
@@ -115,7 +115,9 @@ public class RemoteSignatureSource extends SignatureSource {
       // If an exception occurs, wait 10 seconds, and retry only once by rebuilding the gRPC client stub from a new Channel
       try {
         Thread.sleep(10_000);
-      } catch (InterruptedException ex) {}
+      } catch (InterruptedException ex) {
+        // Ignore the fact that we got interrupted
+      }
       serviceStub = SignatureSourceGrpc.newBlockingStub(channelBuilder.build());
       response = serviceStub.getSignature(GetSignatureRequest.newBuilder().setIndex(index).setHash(hash).build());
     }

--- a/compass/sign/RemoteSignatureSource.java
+++ b/compass/sign/RemoteSignatureSource.java
@@ -103,7 +103,10 @@ public class RemoteSignatureSource extends SignatureSource {
     try {
       response = serviceStub.getSignature(GetSignatureRequest.newBuilder().setIndex(index).setHash(hash).build());
     } catch (StatusRuntimeException e) {
-      // If an exception occurs we retry only once by rebuilding the gRPC client stub from a new Channel
+      // If an exception occurs, wait 10 seconds, and retry only once by rebuilding the gRPC client stub from a new Channel
+      try {
+        Thread.sleep(10000);
+      } catch (InterruptedException ex) {}
       serviceStub = SignatureSourceGrpc.newBlockingStub(channelBuilder.build());
       response = serviceStub.getSignature(GetSignatureRequest.newBuilder().setIndex(index).setHash(hash).build());
     }


### PR DESCRIPTION
Use the same ManagedChannelBuilder, but recreate the gRPC client Stub upon network exception from a brand new ChannelBuilder.
Additionally JVM internal DNS cache has been limited 5 seconds, for positive and negative lookups (https://docs.oracle.com/javase/7/docs/technotes/guides/net/properties.html).

Conflicts will be resolved by reverting previous iteration of this PR https://github.com/iotaledger/compass/pull/127