### PR TITLE
Remove changing gTTA depth logic, default to 0 depth

### DIFF
--- a/compass/Coordinator.java
+++ b/compass/Coordinator.java
@@ -331,6 +331,7 @@ public class Coordinator {
       state.latestMilestoneIndex++;
 
       createAndBroadcastMilestone(trunk, branch);
+      state.latestMilestoneTime = System.currentTimeMillis();
 
       // Everything went fine, now we store
       try {

--- a/compass/Coordinator.java
+++ b/compass/Coordinator.java
@@ -159,36 +159,6 @@ public class Coordinator {
   }
 
   /**
-   * Computes the next depth to use for getTransactionsToApprove call.
-   *
-   * @param currentDepth tip selection depth from the current round
-   * @param lastTimestamp when the current round started
-   * @return depth for the next round
-   */
-  private int getNextDepth(int currentDepth, long lastTimestamp) {
-    long now = System.currentTimeMillis();
-    int nextDepth;
-
-    log.info("Timestamp delta: " + ((now - lastTimestamp)));
-
-    if ((now - lastTimestamp) > ((int) (config.depthScale * Long.valueOf(milestoneTick).floatValue()))) {
-      // decrease depth as we took too long.
-      nextDepth = currentDepth * 2 / 3;
-    } else {
-      // increase depth as we seem to have room for growth
-      nextDepth = currentDepth * 4 / 3;
-    }
-
-    if (nextDepth < config.minDepth) {
-      nextDepth = config.minDepth;
-    } else if (nextDepth > config.maxDepth) {
-      nextDepth = config.maxDepth;
-    }
-
-    return nextDepth;
-  }
-
-  /**
    * Checks that node is solid, bootstrapped and on latest milestone.
    *
    * @param nodeInfo response from node API call
@@ -241,10 +211,10 @@ public class Coordinator {
 
 
     depth = config.depth;
-    if (depth <= 0) {
-      throw new IllegalArgumentException("depth must be > 0");
+    if (depth < 0) {
+      throw new IllegalArgumentException("depth must be >= 0");
     }
-    log.info("Setting initial depth to: " + depth);
+    log.info("Setting depth to: " + depth);
 
     log.info("Validating Coordinator addresses.");
     if (!Objects.equals(nodeInfoResponse.getCoordinatorAddress(), db.getRoot())) {
@@ -361,8 +331,6 @@ public class Coordinator {
       state.latestMilestoneIndex++;
 
       createAndBroadcastMilestone(trunk, branch);
-      updateDepth(bootstrapStage, isReferencingLastMilestone);
-      state.latestMilestoneTime = System.currentTimeMillis();
 
       // Everything went fine, now we store
       try {
@@ -386,24 +354,6 @@ public class Coordinator {
         Thread.sleep(milestoneTick);
       }
     }
-  }
-
-  private void updateDepth(int bootstrap, boolean minimizeDepth) {
-    if (minimizeDepth) {
-      depth = config.minDepth;
-      return;
-    }
-
-    int nextDepth;
-    if (bootstrap >= 3) {
-      nextDepth = getNextDepth(depth, state.latestMilestoneTime);
-    } else {
-      nextDepth = depth;
-    }
-
-    log.info("Depth: " + depth + " -> " + nextDepth);
-
-    depth = nextDepth;
   }
 
   private void createAndBroadcastMilestone(String trunk, String branch) throws InterruptedException {

--- a/compass/conf/CoordinatorConfiguration.java
+++ b/compass/conf/CoordinatorConfiguration.java
@@ -38,13 +38,7 @@ public class CoordinatorConfiguration extends BaseConfiguration {
   public int tick = 15000;
 
   @Parameter(names = "-depth", description = "Starting depth")
-  public int depth = 3;
-
-  @Parameter(names = "-minDepth", description = "Minimal depth")
-  public int minDepth = 3;
-
-  @Parameter(names = "-maxDepth", description = "Maximal depth")
-  public int maxDepth = 1000;
+  public int depth = 0;
 
   @Parameter(names = "-depthScale", description = "Time scale factor for depth decrease")
   public float depthScale = 1.01f;

--- a/compass/conf/CoordinatorState.java
+++ b/compass/conf/CoordinatorState.java
@@ -33,6 +33,7 @@ public class CoordinatorState implements Serializable {
 
   public int latestMilestoneIndex;
   public String latestMilestoneHash;
+  public long latestMilestoneTime;
   public List<String> latestMilestoneTransactions = Collections.EMPTY_LIST;
 
 }

--- a/compass/conf/CoordinatorState.java
+++ b/compass/conf/CoordinatorState.java
@@ -33,7 +33,6 @@ public class CoordinatorState implements Serializable {
 
   public int latestMilestoneIndex;
   public String latestMilestoneHash;
-  public long latestMilestoneTime;
   public List<String> latestMilestoneTransactions = Collections.EMPTY_LIST;
 
 }


### PR DESCRIPTION
* Depth was not used in bootstrap phase, as the genesis transaction is always explicitly attached to, even if `depth` was adjusted at every cycle to `minDepth`;
* the `updateDepth` logic was time-based on gTTA times; it is unreliable and with possible unexpected results: removed min and max depth ranges configuration options and just rely on one and fixed initial depth value;
* default `depth` to 0.